### PR TITLE
Allow setting the schema version to be used by the HttpClient

### DIFF
--- a/src/main/kotlin/com/kryszak/gwatlin/http/AuthenticatedHttpClient.kt
+++ b/src/main/kotlin/com/kryszak/gwatlin/http/AuthenticatedHttpClient.kt
@@ -6,11 +6,15 @@ import com.github.kittinunf.fuel.httpGet
 import com.kryszak.gwatlin.http.exception.RetrieveError
 import com.kryszak.gwatlin.http.exception.ErrorResponse
 
-internal open class AuthenticatedHttpClient(val apiKey: String) : BaseHttpClient() {
+internal open class AuthenticatedHttpClient(
+    val apiKey: String,
+    schemaVersion: String? = null
+) : BaseHttpClient(schemaVersion) {
 
     protected inline fun <reified T : Any> getRequestAuth(uri: String): T {
         val (_, response, result) = "$baseUrl/$uri"
                 .httpGet()
+                .also { addDefaultHeaders(it) }
                 .also { log.info(logMessage.format(it.url)) }
                 .authentication()
                 .bearer(apiKey)


### PR DESCRIPTION
It's necessary to specify the schema version to create an up-to-date implementation for the "characters" endpoint, as the default schema version doesn't include build templates etc.
See #5 for my progress on implementing that endpoint.

For this, I propose adding a property to the constructor of both HttpClients, as this doesn't interfere with the implementations for the other endpoints and allows incrementally updating each endpoint independent from another.

There aren't any breaking changes as this only adds the "X-Schema-Version" header when a version is specified in the constructor.