### PR TITLE
Use internal Gson instance when deserializing responses

### DIFF
--- a/src/main/kotlin/com/kryszak/gwatlin/http/AuthenticatedHttpClient.kt
+++ b/src/main/kotlin/com/kryszak/gwatlin/http/AuthenticatedHttpClient.kt
@@ -18,7 +18,7 @@ internal open class AuthenticatedHttpClient(
                 .also { log.info(logMessage.format(it.url)) }
                 .authentication()
                 .bearer(apiKey)
-                .responseObject<T>()
+                .responseObject<T>(gson)
 
         return processResult(result, ErrorResponse(response, RetrieveError::class.java))
     }

--- a/src/main/kotlin/com/kryszak/gwatlin/http/BaseHttpClient.kt
+++ b/src/main/kotlin/com/kryszak/gwatlin/http/BaseHttpClient.kt
@@ -24,7 +24,7 @@ internal open class BaseHttpClient(
 
     protected val baseUrl: String
 
-    private val gson = Gson()
+    protected val gson = Gson()
 
     private val httpConfig: HttpConfig = HttpConfig()
 
@@ -37,7 +37,7 @@ internal open class BaseHttpClient(
                 .httpGet()
                 .also { addDefaultHeaders(it) }
                 .also { log.info(logMessage.format(it.url)) }
-                .responseObject<T>()
+                .responseObject<T>(gson)
 
         return processResult(result, ErrorResponse(response, RetrieveError::class.java))
     }


### PR DESCRIPTION
This is just a minor change. 
Currently, responses get deserialized by creating a new default Gson instance each time when calling responseObject(). The HttpClient classes have an internal Gson instance anyway to parse error messages, so why not use it for deserializing the responses as well?