### PR TITLE
#25 add documentation generation tool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,12 @@ jobs:
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
       - name: Push documentation
-        uses: nkoppel/push-files-to-another-repository@v1.1.1
+        uses: cpina/github-action-push-to-another-repository@main
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
-          source-files: 'build/dokka/'
-          destination-username: 'Kryszak'
-          destination-repository: 'gwatlin-docs.github.io'
-          commit-email: '13157331+Kryszak@users.noreply.github.com'
+          source-directory: 'build/dokka'
+          destination-github-username: "Kryszak"
+          destination-repository-name: "gwatlin-docs.github.io"
+          user-email: 13157331+Kryszak@users.noreply.github.com
+          target-branch: master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
-          source-directory: 'build/dokka'
+          source-directory: 'build/dokka/html'
           destination-github-username: "Kryszak"
           destination-repository-name: "gwatlin-docs.github.io"
           user-email: 13157331+Kryszak@users.noreply.github.com

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,12 @@ jobs:
         uses: codacy/codacy-coverage-reporter-action@v1
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      - name: Push documentation
+        uses: nkoppel/push-files-to-another-repository@1.1.0
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-files: 'build/dokka/'
+          destination-username: 'Kryszak'
+          destination-repository: 'gwatlin-docs.github.io'
+          commit-email: '13157331+Kryszak@users.noreply.github.com'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,13 +28,3 @@ jobs:
         uses: codacy/codacy-coverage-reporter-action@v1
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-      - name: Push documentation
-        uses: cpina/github-action-push-to-another-repository@main
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-        with:
-          source-directory: 'build/dokka/html'
-          destination-github-username: "Kryszak"
-          destination-repository-name: "gwatlin-docs.github.io"
-          user-email: 13157331+Kryszak@users.noreply.github.com
-          target-branch: master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
       - name: Push documentation
-        uses: nkoppel/push-files-to-another-repository@1.1.0
+        uses: nkoppel/push-files-to-another-repository@1.1.1
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
       - name: Push documentation
-        uses: nkoppel/push-files-to-another-repository@1.1.1
+        uses: nkoppel/push-files-to-another-repository@v1.1.1
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
-          source-directory: 'build/dokka'
+          source-directory: 'build/dokka/html'
           destination-github-username: "Kryszak"
           destination-repository-name: "gwatlin-docs.github.io"
           user-email: 13157331+Kryszak@users.noreply.github.com

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,6 @@ jobs:
         with:
           source-directory: 'build/dokka/html'
           destination-github-username: "Kryszak"
-          destination-repository-name: "gwatlin-docs.github.io"
+          destination-repository-name: "gwatlin-docs"
           user-email: 13157331+Kryszak@users.noreply.github.com
           target-branch: master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,3 +31,12 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: "build/libs/*"
+      - name: Push documentation
+        uses: nkoppel/push-files-to-another-repository@1.1.0
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-files: 'build/dokka/'
+          destination-username: 'Kryszak'
+          destination-repository: 'gwatlin-docs.github.io'
+          commit-email: '13157331+Kryszak@users.noreply.github.com'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,11 +32,12 @@ jobs:
         with:
           artifacts: "build/libs/*"
       - name: Push documentation
-        uses: nkoppel/push-files-to-another-repository@v1.1.1
+        uses: cpina/github-action-push-to-another-repository@main
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
-          source-files: 'build/dokka/'
-          destination-username: 'Kryszak'
-          destination-repository: 'gwatlin-docs.github.io'
-          commit-email: '13157331+Kryszak@users.noreply.github.com'
+          source-directory: 'build/dokka'
+          destination-github-username: "Kryszak"
+          destination-repository-name: "gwatlin-docs.github.io"
+          user-email: 13157331+Kryszak@users.noreply.github.com
+          target-branch: master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,5 +39,5 @@ jobs:
           source-directory: 'build/dokka/html'
           destination-github-username: "Kryszak"
           destination-repository-name: "gwatlin-docs"
-          user-email: 13157331+Kryszak@users.noreply.github.com
+          user-email: github-actions[bot]@users.noreply.github.com
           target-branch: master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           artifacts: "build/libs/*"
       - name: Push documentation
-        uses: nkoppel/push-files-to-another-repository@1.1.0
+        uses: nkoppel/push-files-to-another-repository@1.1.1
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           artifacts: "build/libs/*"
       - name: Push documentation
-        uses: nkoppel/push-files-to-another-repository@1.1.1
+        uses: nkoppel/push-files-to-another-repository@v1.1.1
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Issue should contain example json response for given endpoint.
 Artifact is available on GitHub Maven repository: [Instructions](https://github.com/Kryszak/gwatlin/packages/1509407)
 
 ### Documentation
-For full code documentation visit [documentation page](https://kryszak.github.io/gwatlin-docs.github.io/)
+For full code documentation visit [documentation page](https://kryszak.github.io/gwatlin-docs//)
 
 ### Code
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Issue should contain example json response for given endpoint.
 ## Example usage
 Artifact is available on GitHub Maven repository: [Instructions](https://github.com/Kryszak/gwatlin/packages/1509407)
 
+### Documentation
+For full code documentation visit [documentation page](https://kryszak.github.io/gwatlin-docs.github.io/)
+
 ### Code
 ```kotlin
 // Client without API KEY

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,10 @@
+import org.jetbrains.dokka.gradle.DokkaTask
+
 plugins {
     groovy
     jacoco
     id("maven-publish")
+    id("org.jetbrains.dokka") version "1.8.10"
     kotlin("jvm") version "1.8.20"
 }
 
@@ -50,6 +53,10 @@ tasks.jacocoTestReport {
 tasks.test {
     useJUnitPlatform()
     finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.build {
+    finalizedBy(tasks.dokkaHtml)
 }
 
 publishing {

--- a/src/main/kotlin/com/kryszak/gwatlin/http/BaseHttpClient.kt
+++ b/src/main/kotlin/com/kryszak/gwatlin/http/BaseHttpClient.kt
@@ -13,9 +13,9 @@ import com.kryszak.gwatlin.api.mapinfo.model.Rectangle
 import com.kryszak.gwatlin.http.config.HttpConfig
 import com.kryszak.gwatlin.http.exception.ErrorResponse
 import com.kryszak.gwatlin.http.exception.RetrieveError
-import com.kryszak.gwatlin.serializers.DimensionsSerializer
-import com.kryszak.gwatlin.serializers.PairSerializer
-import com.kryszak.gwatlin.serializers.RectangleSerializer
+import com.kryszak.gwatlin.http.serializers.DimensionsSerializer
+import com.kryszak.gwatlin.http.serializers.PairSerializer
+import com.kryszak.gwatlin.http.serializers.RectangleSerializer
 import mu.KotlinLogging
 
 internal open class BaseHttpClient(

--- a/src/main/kotlin/com/kryszak/gwatlin/http/serializers/DimensionsSerializer.kt
+++ b/src/main/kotlin/com/kryszak/gwatlin/http/serializers/DimensionsSerializer.kt
@@ -1,13 +1,11 @@
-package com.kryszak.gwatlin.serializers
+package com.kryszak.gwatlin.http.serializers
 
 import com.google.gson.*
 import com.kryszak.gwatlin.api.mapinfo.model.Dimensions
 import java.lang.reflect.Type
 
-/**
- * Type adapter for [com.kryszak.gwatlin.api.mapinfo.model.Dimensions], supporting serialization and deserialization
- */
-class DimensionsSerializer: JsonSerializer<Dimensions>, JsonDeserializer<Dimensions> {
+
+internal class DimensionsSerializer : JsonSerializer<Dimensions>, JsonDeserializer<Dimensions> {
     override fun serialize(src: Dimensions?, typeOfSrc: Type?, context: JsonSerializationContext): JsonElement {
         return context.serialize(src?.asPair())
     }

--- a/src/main/kotlin/com/kryszak/gwatlin/http/serializers/PairSerializer.kt
+++ b/src/main/kotlin/com/kryszak/gwatlin/http/serializers/PairSerializer.kt
@@ -1,12 +1,9 @@
-package com.kryszak.gwatlin.serializers
+package com.kryszak.gwatlin.http.serializers
 
 import com.google.gson.*
 import java.lang.reflect.Type
 
-/**
- * Type adapter for [Pair], supporting serialization only
- */
-class PairSerializer: JsonSerializer<Pair<Any, Any>> {
+internal class PairSerializer: JsonSerializer<Pair<Any, Any>> {
     override fun serialize(src: Pair<Any, Any>?, typeOfSrc: Type?, context: JsonSerializationContext): JsonElement = src?.let {
         val jsonArray = JsonArray()
         jsonArray.add(context.serialize(it.first))

--- a/src/main/kotlin/com/kryszak/gwatlin/http/serializers/RectangleSerializer.kt
+++ b/src/main/kotlin/com/kryszak/gwatlin/http/serializers/RectangleSerializer.kt
@@ -1,14 +1,11 @@
-package com.kryszak.gwatlin.serializers
+package com.kryszak.gwatlin.http.serializers
 
 import com.google.gson.*
 import com.kryszak.gwatlin.api.mapinfo.model.Dimensions
 import com.kryszak.gwatlin.api.mapinfo.model.Rectangle
 import java.lang.reflect.Type
 
-/**
- * Type adapter for [com.kryszak.gwatlin.api.mapinfo.model.Rectangle], supporting serialization and deserialization
- */
-class RectangleSerializer: JsonSerializer<Rectangle>, JsonDeserializer<Rectangle> {
+internal class RectangleSerializer: JsonSerializer<Rectangle>, JsonDeserializer<Rectangle> {
     override fun serialize(src: Rectangle?, typeOfSrc: Type?, context: JsonSerializationContext): JsonElement {
         return context.serialize(src?.asPair())
     }


### PR DESCRIPTION
Dokka documentation generation is introduced with this change.
Generated documentation is pushed to separate repository: https://github.com/Kryszak/gwatlin-docs
From there, documentation is auto-deployed to Github Pages: https://kryszak.github.io/gwatlin-docs/

Whole `serializers` package was moved into `http` package for two reasons:
- hide serializers from public view
- exclude those classes from public documentation