### PR TITLE
Release artifact to maven central

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Publish package
-        run: ./gradlew clean build publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew clean build publish closeAndReleaseStagingRepository
       - name: Create GitHub release
         uses: ncipollo/release-action@v1
         with:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/6888080bc19640b4ad89efd0fd84ad9e)](https://app.codacy.com/gh/Kryszak/gwatlin/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/6888080bc19640b4ad89efd0fd84ad9e)](https://www.codacy.com/gh/Kryszak/gwatlin/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Kryszak/gwatlin&amp;utm_campaign=Badge_Grade)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.kryszak/gwatlin.svg)](https://search.maven.org/artifact/io.github.kryszak/gwatlin)
 
 # Gwatlin
 **G**uild **W**ars 2 **A**PI client written in Ko**tlin**
@@ -35,7 +36,7 @@ Issue should contain example json response for given endpoint.
 | World vs. World   | :heavy_check_mark: |
 
 ## Example usage
-Artifact is available on GitHub Maven repository: [Instructions](https://github.com/Kryszak/gwatlin/packages/1509407)
+Artifact is available on Maven Central repository.
 
 ### Documentation
 For full code documentation visit [documentation page](https://kryszak.github.io/gwatlin-docs/)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,12 +15,12 @@ plugins {
 project.group = "io.github.kryszak"
 project.version = "1.8"
 
-object Meta {
-    const val desc = "Guild Wars 2 API client"
-    const val license = "MiT"
-    const val githubRepo = "Kryszak/gwatlin"
-    const val release = "https://s01.oss.sonatype.org/service/local/"
-    const val snapshot = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+internal object Meta {
+    const val DESCRIPTION = "Guild Wars 2 API client"
+    const val LICENSE = "MiT"
+    const val GITHUB_REPOSITORY = "Kryszak/gwatlin"
+    const val RELEASE = "https://s01.oss.sonatype.org/service/local/"
+    const val SNAPSHOT = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
 }
 
 kotlin {
@@ -98,11 +98,11 @@ publishing {
             artifact(tasks["javadocJar"])
             pom {
                 name.set(project.name)
-                description.set(Meta.desc)
-                url.set("https://github.com/${Meta.githubRepo}")
+                description.set(Meta.DESCRIPTION)
+                url.set("https://github.com/${Meta.GITHUB_REPOSITORY}")
                 licenses {
                     license {
-                        name.set(Meta.license)
+                        name.set(Meta.LICENSE)
                         url.set("https://opensource.org/licenses/MIT")
                     }
                 }
@@ -114,17 +114,17 @@ publishing {
                 }
                 scm {
                     url.set(
-                        "https://github.com/${Meta.githubRepo}.git"
+                        "https://github.com/${Meta.GITHUB_REPOSITORY}.git"
                     )
                     connection.set(
-                        "scm:git:git://github.com/${Meta.githubRepo}.git"
+                        "scm:git:git://github.com/${Meta.GITHUB_REPOSITORY}.git"
                     )
                     developerConnection.set(
-                        "scm:git:git://github.com/${Meta.githubRepo}.git"
+                        "scm:git:git://github.com/${Meta.GITHUB_REPOSITORY}.git"
                     )
                 }
                 issueManagement {
-                    url.set("https://github.com/${Meta.githubRepo}/issues")
+                    url.set("https://github.com/${Meta.GITHUB_REPOSITORY}/issues")
                 }
             }
         }
@@ -134,8 +134,8 @@ publishing {
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri(Meta.release))
-            snapshotRepositoryUrl.set(uri(Meta.snapshot))
+            nexusUrl.set(uri(Meta.RELEASE))
+            snapshotRepositoryUrl.set(uri(Meta.SNAPSHOT))
             val ossrhUsername = providers
                 .environmentVariable("OSSRH_USERNAME")
             val ossrhPassword = providers

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,10 +4,152 @@ plugins {
     val kotlinVersion = "1.9.10"
     groovy
     jacoco
+    signing
     id("maven-publish")
     id("org.jetbrains.dokka") version "1.9.0"
     kotlin("jvm") version kotlinVersion
     kotlin("plugin.serialization") version kotlinVersion
+    id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
+}
+
+project.group = "io.github.kryszak"
+project.version = "1.8"
+
+object Meta {
+    const val desc = "Guild Wars 2 API client"
+    const val license = "MiT"
+    const val githubRepo = "Kryszak/gwatlin"
+    const val release = "https://s01.oss.sonatype.org/service/local/"
+    const val snapshot = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+}
+
+kotlin {
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+jacoco {
+    toolVersion = "0.8.9"
+}
+
+tasks {
+    jacocoTestReport {
+        dependsOn(test)
+        reports {
+            xml.required.set(true)
+            html.required.set(false)
+        }
+    }
+    test {
+        useJUnitPlatform()
+        finalizedBy(jacocoTestReport)
+    }
+    build {
+        finalizedBy(dokkaHtml)
+    }
+    withType<DokkaTask>().configureEach {
+        dokkaSourceSets {
+            named("main") {
+                moduleName.set("gwatlin")
+                includes.from("Module.md")
+                perPackageOption {
+                    matchingRegex.set(".*api.*")
+                    suppress.set(false)
+                }
+            }
+            configureEach {
+                perPackageOption {
+                    matchingRegex.set(".*")
+                    suppress.set(true)
+                }
+            }
+        }
+    }
+}
+
+signing {
+    val signingKey = providers
+        .environmentVariable("GPG_SIGNING_KEY")
+    val signingPassphrase = providers
+        .environmentVariable("GPG_SIGNING_PASSPHRASE")
+
+    if (signingKey.isPresent && signingPassphrase.isPresent) {
+        useInMemoryPgpKeys(signingKey.get(), signingPassphrase.get())
+        val extension = extensions
+            .getByName("publishing") as PublishingExtension
+        sign(extension.publications)
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            groupId = project.group.toString()
+            artifactId = project.name
+            version = project.version.toString()
+            from(components["kotlin"])
+            artifact(tasks["sourcesJar"])
+            artifact(tasks["javadocJar"])
+            pom {
+                name.set(project.name)
+                description.set(Meta.desc)
+                url.set("https://github.com/${Meta.githubRepo}")
+                licenses {
+                    license {
+                        name.set(Meta.license)
+                        url.set("https://opensource.org/licenses/MIT")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("kryszak")
+                        name.set("Krzysztof Prajs")
+                    }
+                }
+                scm {
+                    url.set(
+                        "https://github.com/${Meta.githubRepo}.git"
+                    )
+                    connection.set(
+                        "scm:git:git://github.com/${Meta.githubRepo}.git"
+                    )
+                    developerConnection.set(
+                        "scm:git:git://github.com/${Meta.githubRepo}.git"
+                    )
+                }
+                issueManagement {
+                    url.set("https://github.com/${Meta.githubRepo}/issues")
+                }
+            }
+        }
+    }
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            nexusUrl.set(uri(Meta.release))
+            snapshotRepositoryUrl.set(uri(Meta.snapshot))
+            val ossrhUsername = providers
+                .environmentVariable("OSSRH_USERNAME")
+            val ossrhPassword = providers
+                .environmentVariable("OSSRH_PASSWORD")
+            if (ossrhUsername.isPresent && ossrhPassword.isPresent) {
+                username.set(ossrhUsername.get())
+                password.set(ossrhPassword.get())
+            }
+        }
+    }
+}
+
+repositories {
+    mavenCentral()
 }
 
 val fuelVersion = "2.3.1"
@@ -17,76 +159,6 @@ val logbackVersion = "1.4.11"
 val kotestVersion = "5.7.2"
 val kotestWiremockExtensionVersion = "2.0.1"
 val kotlinWiremockDslVersion = "2.0.2"
-
-project.group = "io.github.kryszak"
-project.version = "1.8"
-
-kotlin {
-    jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
-}
-
-java {
-    withJavadocJar()
-}
-
-jacoco {
-    toolVersion = "0.8.9"
-}
-
-tasks.withType<DokkaTask>().configureEach {
-    dokkaSourceSets {
-        named("main") {
-            moduleName.set("gwatlin")
-            includes.from("Module.md")
-            perPackageOption {
-                matchingRegex.set(".*api.*")
-                suppress.set(false)
-            }
-        }
-        configureEach {
-            perPackageOption {
-                matchingRegex.set(".*")
-                suppress.set(true)
-            }
-        }
-    }
-}
-
-tasks.jacocoTestReport {
-    dependsOn(tasks.test)
-    reports {
-        xml.required.set(true)
-        html.required.set(false)
-    }
-}
-
-tasks.test {
-    useJUnitPlatform()
-    finalizedBy(tasks.jacocoTestReport)
-}
-
-tasks.build {
-    finalizedBy(tasks.dokkaHtml)
-}
-
-publishing {
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/kryszak/gwatlin")
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-    }
-}
-
-repositories {
-    mavenCentral()
-}
 
 dependencies {
     // http


### PR DESCRIPTION
Release process tested on lib version 1.7:
https://central.sonatype.com/artifact/io.github.kryszak/gwatlin

This PR introduces automated releasing artifact to central maven repository and drops github packages.
Github repository package wasn't used by anyone.