### PR TITLE
Adding relics and changing types of various attributes

### DIFF
--- a/src/main/kotlin/io/github/kryszak/gwatlin/api/items/model/item/InfusionSlot.kt
+++ b/src/main/kotlin/io/github/kryszak/gwatlin/api/items/model/item/InfusionSlot.kt
@@ -9,5 +9,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class InfusionSlot(
     val flags: List<String>,
-    @SerialName("item_id") val itemId: Int
+    @SerialName("item_id") val itemId: Int? = null
 )

--- a/src/main/kotlin/io/github/kryszak/gwatlin/api/items/model/item/Item.kt
+++ b/src/main/kotlin/io/github/kryszak/gwatlin/api/items/model/item/Item.kt
@@ -34,7 +34,7 @@ data class ArmorItem(
     @SerialName("chat_link") override val chatLink: String,
     override val name: String,
     override val icon: String,
-    override val description: String,
+    override val description: String = "",
     override val type: ItemType,
     override val rarity: ItemRarity,
     override val level: Int,
@@ -144,7 +144,7 @@ data class CraftingMaterialItem(
     @SerialName("chat_link") override val chatLink: String,
     override val name: String,
     override val icon: String,
-    override val description: String,
+    override val description: String = "",
     override val type: ItemType,
     override val rarity: ItemRarity,
     override val level: Int,
@@ -364,7 +364,7 @@ data class TrophyItem(
     @SerialName("chat_link") override val chatLink: String,
     override val name: String,
     override val icon: String,
-    override val description: String,
+    override val description: String = "",
     override val type: ItemType,
     override val rarity: ItemRarity,
     override val level: Int,
@@ -408,7 +408,7 @@ data class WeaponItem(
     @SerialName("chat_link") override val chatLink: String,
     override val name: String,
     override val icon: String,
-    override val description: String,
+    override val description: String = "",
     override val type: ItemType,
     override val rarity: ItemRarity,
     override val level: Int,
@@ -418,4 +418,26 @@ data class WeaponItem(
     @SerialName("game_types") override val gameTypes: List<String> = listOf(),
     override val restrictions: List<String> = listOf(),
     override val details: WeaponDetails? = null
+) : Item()
+
+/**
+ * Data model for relic item
+ */
+@Serializable
+@SerialName("Relic")
+data class RelicItem(
+    override val id: Int,
+    @SerialName("chat_link") override val chatLink: String,
+    override val name: String,
+    override val icon: String,
+    override val description: String,
+    override val type: ItemType,
+    override val rarity: ItemRarity,
+    override val level: Int,
+    @SerialName("vendor_value") override val vendorValue: Int,
+    @SerialName("default_skin") override val defaultSkin: Int? = null,
+    override val flags: List<String> = listOf(),
+    @SerialName("game_types") override val gameTypes: List<String> = listOf(),
+    override val restrictions: List<String> = listOf(),
+    override val details: ItemDetails? = null
 ) : Item()

--- a/src/main/kotlin/io/github/kryszak/gwatlin/api/items/model/item/ItemDetails.kt
+++ b/src/main/kotlin/io/github/kryszak/gwatlin/api/items/model/item/ItemDetails.kt
@@ -116,7 +116,7 @@ data class SalvageKitDetails(
 data class TrinketDetails(
     val type: String,
     @SerialName("infusion_slots") val infusionSlots: List<InfusionSlot> = listOf(),
-    @SerialName("attribute_adjustment") val attributeAdjustment: Int,
+    @SerialName("attribute_adjustment") val attributeAdjustment: Double,
     @SerialName("infix_upgrade") val infixUpgrade: InfixUpgrade? = null,
     @SerialName("suffix_item_id") val suffixItemId: Int? = null,
     @SerialName("secondary_suffix_item_id") val secondarySuffixItemId: String,
@@ -148,7 +148,7 @@ data class WeaponDetails(
     @SerialName("max_power") val maxPower: Int,
     val defense: Double,
     @SerialName("infusion_slots") val infusionSlots: List<InfusionSlot> = listOf(),
-    @SerialName("attribute_adjustment") val attributeAdjustment: Int? = null,
+    @SerialName("attribute_adjustment") val attributeAdjustment: Double? = null,
     @SerialName("infix_upgrade") val infixUpgrade: InfixUpgrade? = null,
     @SerialName("suffix_item_id") val suffixItemId: Int? = null,
     @SerialName("secondary_suffix_item_id") val secondarySuffixItemId: String,

--- a/src/main/kotlin/io/github/kryszak/gwatlin/api/items/model/item/ItemType.kt
+++ b/src/main/kotlin/io/github/kryszak/gwatlin/api/items/model/item/ItemType.kt
@@ -40,6 +40,8 @@ enum class ItemType {
     TRINKET,
     @SerialName("Trophy")
     TROPHY,
+    @SerialName("Relic")
+    RELIC,
     @SerialName("UpgradeComponent")
     UPGRADE_COMPONENT,
     @SerialName("Weapon")

--- a/src/main/kotlin/io/github/kryszak/gwatlin/clients/characters/CharactersClient.kt
+++ b/src/main/kotlin/io/github/kryszak/gwatlin/clients/characters/CharactersClient.kt
@@ -43,7 +43,7 @@ internal class CharactersClient(apiKey: String) : AuthenticatedHttpClient(
         getRequestAuth<List<EquipmentTab>>("$endpoint/$characterName/equipmenttabs?tabs=all")
 
     fun getInventory(characterName: String) =
-        getRequestAuth<Map<String, List<Bag>>>("$endpoint/$characterName/inventory").values.firstOrNull()
+        getRequestAuth<Map<String, List<Bag?>>>("$endpoint/$characterName/inventory").values.firstOrNull()
 
     fun getRecipes(characterName: String) =
         getRequestAuth<Map<String, List<Int>>>("$endpoint/$characterName/recipes").values.firstOrNull()

--- a/src/test/kotlin/io/github/kryszak/gwatlin/api/characters/CharactersClientTest.kt
+++ b/src/test/kotlin/io/github/kryszak/gwatlin/api/characters/CharactersClientTest.kt
@@ -390,8 +390,8 @@ internal class CharactersClientTest : BaseWiremockTest() {
 
             // then
             assertSoftly(bag!!) {
-                size shouldBe 6
-                assertSoftly(it[0]) {
+                size shouldBe 7
+                assertSoftly(it[0]!!) {
                     assertSoftly(inventory[6]!!) {
                         id shouldBe 2258
                         upgrades shouldBe listOf(24774)
@@ -410,7 +410,7 @@ internal class CharactersClientTest : BaseWiremockTest() {
                         boundTo shouldBe characterName
                     }
                 }
-                assertSoftly(it[1]) {
+                assertSoftly(it[1]!!) {
                     id shouldBe 45053
                     size shouldBe 18
                     inventory shouldHaveSize 18
@@ -422,7 +422,7 @@ internal class CharactersClientTest : BaseWiremockTest() {
                         boundTo shouldBe characterName
                     }
                 }
-                assertSoftly(it[4]) {
+                assertSoftly(it[4]!!) {
                     id shouldBe 9423
                     size shouldBe 15
                     inventory shouldHaveSize 15
@@ -433,6 +433,7 @@ internal class CharactersClientTest : BaseWiremockTest() {
                         binding shouldBe ItemBinding.ACCOUNT
                     }
                 }
+                it[6] shouldBe null
             }
         }
 

--- a/src/test/kotlin/io/github/kryszak/gwatlin/api/items/ItemsClientTest.kt
+++ b/src/test/kotlin/io/github/kryszak/gwatlin/api/items/ItemsClientTest.kt
@@ -37,6 +37,7 @@ internal class ItemsClientTest : BaseWiremockTest() {
                 mapOf(
                     "armor" to ItemTestInput(1234, "armor_item.json", ::armorAssertion),
                     "back" to ItemTestInput(56, "back_item.json", ::backAssertion),
+                    "back infusion" to ItemTestInput(56, "back_infusion_item.json", ::backInfusionAssertion),
                     "bag" to ItemTestInput(1371, "bag_item.json", ::bagAssertion),
                     "consumable" to ItemTestInput(12421, "consumable_item.json", ::consumableAssertion),
                     "container" to ItemTestInput(9335, "container_item.json", ::containerAssertion),
@@ -50,7 +51,9 @@ internal class ItemsClientTest : BaseWiremockTest() {
                     "jade tech" to ItemTestInput(97656, "jade_tech_item.json", ::jadeTechAssertion),
                     "miniature" to ItemTestInput(47845, "miniature_item.json", ::miniatureAssertion),
                     "power core" to ItemTestInput(97020, "power_core_item.json", ::powerCoreAssertion),
+                    "relic" to ItemTestInput(70093, "relic_item.json", ::relicAssertion),
                     "tool" to ItemTestInput(23041, "salvage_kit_item.json", ::toolAssertion),
+                    "trophy" to ItemTestInput(70093, "trophy_item.json", ::trophyAssertion),
                     "upgrade component" to ItemTestInput(
                         72339,
                         "upgrade_component_item.json",
@@ -136,6 +139,45 @@ internal class ItemsClientTest : BaseWiremockTest() {
                         InfixUpgradeAttribute("Power", 5.0),
                         InfixUpgradeAttribute("Precision", 3.0)
                     )
+                }
+                backItemDetails.secondarySuffixItemId shouldBe ""
+            }
+        }
+
+    private fun backInfusionAssertion(item: Item) =
+        assertSoftly(item) {
+            it should beOfType<BackItem>()
+            name shouldBe "Elegant Armorsmith's Backpack"
+            description shouldBe "This equipment can hold an additional upgrade. Unequip this backpack to use it as a crafting ingredient. Using this as a crafting ingredient will destroy any upgrades held within."
+            type shouldBe ItemType.BACK
+            level shouldBe 78
+            rarity shouldBe ItemRarity.EXOTIC
+            vendorValue shouldBe 256
+            defaultSkin shouldBe 2305
+            gameTypes shouldContainExactly listOf("Activity", "Wvw", "Dungeon", "Pve")
+            flags shouldContainExactly listOf("AccountBound", "NoSalvage", "NoSell", "AccountBindOnUse")
+            restrictions.shouldBeEmpty()
+            id shouldBe 62889
+            chatLink shouldBe "[&AgGp9QAA]"
+            icon shouldBe "https://render.guildwars2.com/file/5893AD0A6C6CB94E66CE0C1613E45172EE9996CD/866528.png"
+            assertSoftly(details!!) {
+                val backItemDetails = details.shouldBeTypeOf<BackItemDetails>()
+                backItemDetails.attributeAdjustment shouldBe 82.34
+                backItemDetails.statChoices shouldContainExactly listOf(
+                    1052,
+                    1042,
+                    1044,
+                    1043,
+                    1046,
+                    1048,
+                    1047,
+                    1041,
+                    1050,
+                    1051
+                )
+                assertSoftly(backItemDetails.infusionSlots) { slots ->
+                    slots[0].itemId.shouldBeNull()
+                    slots[0].flags shouldContainExactly listOf("Infusion")
                 }
                 backItemDetails.secondarySuffixItemId shouldBe ""
             }
@@ -327,6 +369,23 @@ internal class ItemsClientTest : BaseWiremockTest() {
             details.shouldBeNull()
         }
 
+    private fun relicAssertion(item: Item) =
+        assertSoftly(item) {
+            it should beOfType<RelicItem>()
+            name shouldBe "Relic of Isgarren"
+            description shouldBe "After evading an enemy's attack, place the Eye of Isgarren on them for a duration. You deal increased strike and condition duration against enemies with the Eye of Isgarren."
+            type shouldBe ItemType.RELIC
+            level shouldBe 60
+            rarity shouldBe ItemRarity.EXOTIC
+            vendorValue shouldBe 200
+            gameTypes shouldHaveSize 4
+            flags shouldHaveSize 2
+            restrictions.shouldBeEmpty()
+            id shouldBe 99997
+            chatLink shouldBe "[&AgGdhgEA]"
+            icon shouldBe "https://render.guildwars2.com/file/5FB808F04E427650A84031E46B632DC292A3583F/3122354.png"
+        }
+
     private fun toolAssertion(item: Item) =
         assertSoftly(item) {
             it should beOfType<SalvageKitItem>()
@@ -348,6 +407,24 @@ internal class ItemsClientTest : BaseWiremockTest() {
                 salvageKitDetails.charges shouldBe 25
             }
         }
+
+    private fun trophyAssertion(item: Item) =
+        assertSoftly(item) {
+            it should beOfType<TrophyItem>()
+            name shouldBe "Shiny Bauble"
+            description.shouldBeBlank()
+            type shouldBe ItemType.TROPHY
+            level shouldBe 0
+            rarity shouldBe ItemRarity.JUNK
+            vendorValue shouldBe 3000
+            gameTypes shouldHaveSize 5
+            flags shouldHaveSize 4
+            restrictions.shouldBeEmpty()
+            id shouldBe 70093
+            chatLink shouldBe "[&AgHNEQEA]"
+            icon shouldBe "https://render.guildwars2.com/file/034B091471E6067C2B0BCC70FE04D2F3AE51F291/1010539.png"
+        }
+
 
     private fun upgradeComponentAssertion(item: Item) =
         assertSoftly(item) {
@@ -381,29 +458,45 @@ internal class ItemsClientTest : BaseWiremockTest() {
     private fun weaponAssertion(item: Item) =
         assertSoftly(item) {
             it should beOfType<WeaponItem>()
-            name shouldBe "Strong Soft Wood Longbow of Fire"
+            name shouldBe "Celestial Bronze Axe of Force"
             description.shouldBeBlank()
             type shouldBe ItemType.WEAPON
-            level shouldBe 44
-            rarity shouldBe ItemRarity.MASTERWORK
-            vendorValue shouldBe 120
-            defaultSkin shouldBe 3942
-            gameTypes shouldHaveSize 4
-            flags shouldHaveSize 1
+            level shouldBe 80
+            rarity shouldBe ItemRarity.EXOTIC
+            vendorValue shouldBe 0
+            defaultSkin shouldBe 3946
+            gameTypes shouldHaveSize 3
+            flags shouldHaveSize 5
             restrictions.shouldBeEmpty()
-            id shouldBe 28445
-            chatLink shouldBe "[&AgEdbwAA]"
-            icon shouldBe "https://render.guildwars2.com/file/C6110F52DF5AFE0F00A56F9E143E9732176DDDE9/65015.png"
+            id shouldBe 95356
+            chatLink shouldBe "[&AgF8dAEA]"
+            icon shouldBe "https://render.guildwars2.com/file/C8EAC643C02F41B918D79031B6060B0CBFE40CAD/64967.png"
             assertSoftly(details!!) {
                 val weaponDetails = details.shouldBeTypeOf<WeaponDetails>()
-                weaponDetails.type shouldBe "LongBow"
-                weaponDetails.damageType shouldBe "Physical"
-                weaponDetails.minPower shouldBe 385
-                weaponDetails.maxPower shouldBe 452
+                weaponDetails.type shouldBe "Axe"
+                weaponDetails.damageType shouldBe "Choking"
+                weaponDetails.minPower shouldBe 857
+                weaponDetails.maxPower shouldBe 1048
                 weaponDetails.defense shouldBe 0
+                weaponDetails.attributeAdjustment shouldBe 341.44
                 (weaponDetails.infusionSlots as List<*>).shouldBeEmpty()
-                weaponDetails.suffixItemId shouldBe 24547
+                weaponDetails.suffixItemId shouldBe 24615
                 weaponDetails.secondarySuffixItemId shouldBe ""
+                assertSoftly(weaponDetails.infixUpgrade!!) {
+                    id shouldBe 559
+                    attributes shouldHaveSize 9
+                    attributes shouldContainExactly listOf(
+                        InfixUpgradeAttribute("Power", 56.0),
+                        InfixUpgradeAttribute("Precision", 56.0),
+                        InfixUpgradeAttribute("Toughness", 56.0),
+                        InfixUpgradeAttribute("Vitality", 56.0),
+                        InfixUpgradeAttribute("CritDamage", 56.0),
+                        InfixUpgradeAttribute("Healing", 56.0),
+                        InfixUpgradeAttribute("ConditionDamage", 56.0),
+                        InfixUpgradeAttribute("BoonDuration", 56.0),
+                        InfixUpgradeAttribute("ConditionDuration", 56.0),
+                    )
+                }
             }
         }
 

--- a/src/test/resources/responses/characters/inventory.json
+++ b/src/test/resources/responses/characters/inventory.json
@@ -325,6 +325,7 @@
           "binding": "Account"
         }
       ]
-    }
+    },
+    null
   ]
 }

--- a/src/test/resources/responses/items/back_infusion_item.json
+++ b/src/test/resources/responses/items/back_infusion_item.json
@@ -1,0 +1,50 @@
+[
+  {
+    "name": "Elegant Armorsmith's Backpack",
+    "description": "This equipment can hold an additional upgrade. Unequip this backpack to use it as a crafting ingredient. Using this as a crafting ingredient will destroy any upgrades held within.",
+    "type": "Back",
+    "level": 78,
+    "rarity": "Exotic",
+    "vendor_value": 256,
+    "default_skin": 2305,
+    "game_types": [
+      "Activity",
+      "Wvw",
+      "Dungeon",
+      "Pve"
+    ],
+    "flags": [
+      "AccountBound",
+      "NoSalvage",
+      "NoSell",
+      "AccountBindOnUse"
+    ],
+    "restrictions": [],
+    "id": 62889,
+    "chat_link": "[&AgGp9QAA]",
+    "icon": "https://render.guildwars2.com/file/5893AD0A6C6CB94E66CE0C1613E45172EE9996CD/866528.png",
+    "details": {
+      "infusion_slots": [
+        {
+          "flags": [
+            "Infusion"
+          ]
+        }
+      ],
+      "attribute_adjustment": 82.34,
+      "stat_choices": [
+        1052,
+        1042,
+        1044,
+        1043,
+        1046,
+        1048,
+        1047,
+        1041,
+        1050,
+        1051
+      ],
+      "secondary_suffix_item_id": ""
+    }
+  }
+]

--- a/src/test/resources/responses/items/relic_item.json
+++ b/src/test/resources/responses/items/relic_item.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "Relic of Isgarren",
+    "description": "After evading an enemy's attack, place the Eye of Isgarren on them for a duration. You deal increased strike and condition duration against enemies with the Eye of Isgarren.",
+    "type": "Relic",
+    "level": 60,
+    "rarity": "Exotic",
+    "vendor_value": 200,
+    "game_types": [
+      "Activity",
+      "Wvw",
+      "Dungeon",
+      "Pve"
+    ],
+    "flags": [
+      "AccountBound",
+      "SoulBindOnUse"
+    ],
+    "restrictions": [],
+    "id": 99997,
+    "chat_link": "[&AgGdhgEA]",
+    "icon": "https://render.guildwars2.com/file/5FB808F04E427650A84031E46B632DC292A3583F/3122354.png"
+  }
+]

--- a/src/test/resources/responses/items/trophy_item.json
+++ b/src/test/resources/responses/items/trophy_item.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "Shiny Bauble",
+    "type": "Trophy",
+    "level": 0,
+    "rarity": "Junk",
+    "vendor_value": 3000,
+    "game_types": [
+      "PvpLobby",
+      "Activity",
+      "Wvw",
+      "Dungeon",
+      "Pve"
+    ],
+    "flags": [
+      "NoMysticForge",
+      "NoSalvage",
+      "SoulbindOnAcquire",
+      "SoulBindOnUse"
+    ],
+    "restrictions": [],
+    "id": 70093,
+    "chat_link": "[&AgHNEQEA]",
+    "icon": "https://render.guildwars2.com/file/034B091471E6067C2B0BCC70FE04D2F3AE51F291/1010539.png"
+  }
+]

--- a/src/test/resources/responses/items/weapon_item.json
+++ b/src/test/resources/responses/items/weapon_item.json
@@ -1,45 +1,77 @@
 [
   {
-    "name": "Strong Soft Wood Longbow of Fire",
-    "description": "",
+    "name": "Celestial Bronze Axe of Force",
     "type": "Weapon",
-    "level": 44,
-    "rarity": "Masterwork",
-    "vendor_value": 120,
-    "default_skin": 3942,
+    "level": 80,
+    "rarity": "Exotic",
+    "vendor_value": 0,
+    "default_skin": 3946,
     "game_types": [
-      "Activity",
+      "Wvw",
       "Dungeon",
-      "Pve",
-      "Wvw"
+      "Pve"
     ],
     "flags": [
+      "NoMysticForge",
+      "NoSalvage",
+      "NoSell",
+      "SoulbindOnAcquire",
       "SoulBindOnUse"
     ],
     "restrictions": [],
-    "id": 28445,
-    "chat_link": "[&AgEdbwAA]",
-    "icon": "https://render.guildwars2.com/file/C6110F52DF5AFE0F00A56F9E143E9732176DDDE9/65015.png",
+    "id": 95356,
+    "chat_link": "[&AgF8dAEA]",
+    "icon": "https://render.guildwars2.com/file/C8EAC643C02F41B918D79031B6060B0CBFE40CAD/64967.png",
     "details": {
-      "type": "LongBow",
-      "damage_type": "Physical",
-      "min_power": 385,
-      "max_power": 452,
+      "type": "Axe",
+      "damage_type": "Choking",
+      "min_power": 857,
+      "max_power": 1048,
       "defense": 0,
       "infusion_slots": [],
+      "attribute_adjustment": 341.44,
       "infix_upgrade": {
+        "id": 559,
         "attributes": [
           {
             "attribute": "Power",
-            "modifier": 62
+            "modifier": 56
           },
           {
             "attribute": "Precision",
-            "modifier": 44
+            "modifier": 56
+          },
+          {
+            "attribute": "Toughness",
+            "modifier": 56
+          },
+          {
+            "attribute": "Vitality",
+            "modifier": 56
+          },
+          {
+            "attribute": "CritDamage",
+            "modifier": 56
+          },
+          {
+            "attribute": "Healing",
+            "modifier": 56
+          },
+          {
+            "attribute": "ConditionDamage",
+            "modifier": 56
+          },
+          {
+            "attribute": "BoonDuration",
+            "modifier": 56
+          },
+          {
+            "attribute": "ConditionDuration",
+            "modifier": 56
           }
         ]
       },
-      "suffix_item_id": 24547,
+      "suffix_item_id": 24615,
       "secondary_suffix_item_id": ""
     }
   }


### PR DESCRIPTION
These are the changes that I found were necessary to use the wrapper for the given items:
I adapted the tests in some places to have examples of this behavior, but I didnt do it for all of them.

The changes are:
* Relics were missing -> have been added with tests
* Inventory bags can be null -> has changed and adapted test
* Descriptions of Armor, CraftingMaterial, Weapons and Trophies can be missing -> gave them a default value (as this was the case for others already, I figured this was the change more in line with the rest of the models). I created a trophy test and adapted a Weapon test to test this
* Infusion slot can have an itemId that is null -> changed the type and added a test for this particular case
