### PR TITLE
Skill Slot += Elite

### DIFF
--- a/src/main/kotlin/io/github/kryszak/gwatlin/api/gamemechanics/model/facts/Damage.kt
+++ b/src/main/kotlin/io/github/kryszak/gwatlin/api/gamemechanics/model/facts/Damage.kt
@@ -15,7 +15,17 @@ data class Damage(
     @SerialName("hit_count")
     val hitCount: Int,
     @SerialName("dmg_multiplier")
-    val finisherType: Float? = null
+    val dmgMultiplier: Float? = null,
 ) : Fact {
     override val type by serialNameDelegate
+
+    /**
+     *
+     */
+    @Deprecated(
+        message = "Most likely this field was a typo.",
+        replaceWith = ReplaceWith("dmgMultiplier"),
+        level = DeprecationLevel.WARNING,
+    )
+    val finisherType: Float? = dmgMultiplier
 }

--- a/src/main/kotlin/io/github/kryszak/gwatlin/api/gamemechanics/model/skill/SkillSlot.kt
+++ b/src/main/kotlin/io/github/kryszak/gwatlin/api/gamemechanics/model/skill/SkillSlot.kt
@@ -19,5 +19,7 @@ enum class SkillSlot {
     @SerialName("Utility")
     UTILITY,
     @SerialName("Weapon_[1-5]")
-    WEAPON1_5
+    WEAPON1_5,
+    @SerialName("Elite")
+    ELITE,
 }

--- a/src/main/kotlin/io/github/kryszak/gwatlin/api/gamemechanics/model/skill/SkillSlot.kt
+++ b/src/main/kotlin/io/github/kryszak/gwatlin/api/gamemechanics/model/skill/SkillSlot.kt
@@ -22,4 +22,6 @@ enum class SkillSlot {
     WEAPON1_5,
     @SerialName("Elite")
     ELITE,
+    @SerialName("Heal")
+    HEAL,
 }

--- a/src/main/kotlin/io/github/kryszak/gwatlin/api/gamemechanics/model/skill/TraitedFact.kt
+++ b/src/main/kotlin/io/github/kryszak/gwatlin/api/gamemechanics/model/skill/TraitedFact.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Data model for traited fact skill property
+ * Data model for traited fact skill property.
  */
 @Serializable
 data class TraitedFact(

--- a/src/test/kotlin/io/github/kryszak/gwatlin/api/skills/SkillsClientTest.kt
+++ b/src/test/kotlin/io/github/kryszak/gwatlin/api/skills/SkillsClientTest.kt
@@ -2,22 +2,27 @@ package io.github.kryszak.gwatlin.api.skills
 
 import io.github.kryszak.gwatlin.api.ApiLanguage.EN
 import io.github.kryszak.gwatlin.api.gamemechanics.GWSkillsClient
+import io.github.kryszak.gwatlin.api.gamemechanics.model.facts.AttributeAdjust
+import io.github.kryszak.gwatlin.api.gamemechanics.model.facts.Damage
+import io.github.kryszak.gwatlin.api.gamemechanics.model.facts.Fact
+import io.github.kryszak.gwatlin.api.gamemechanics.model.facts.Range
+import io.github.kryszak.gwatlin.api.gamemechanics.model.facts.Recharge
 import io.github.kryszak.gwatlin.api.gamemechanics.model.skill.Skill
 import io.github.kryszak.gwatlin.api.gamemechanics.model.skill.SkillSlot
-import io.github.kryszak.gwatlin.api.items.model.item.*
+import io.github.kryszak.gwatlin.api.gamemechanics.model.skill.SkillType
+import io.github.kryszak.gwatlin.api.gamemechanics.model.skill.TraitedFact
 import io.github.kryszak.gwatlin.config.BaseWiremockTest
 import io.kotest.assertions.assertSoftly
 import io.kotest.datatest.withData
-import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.doubles.plusOrMinus
 import io.kotest.matchers.nulls.shouldBeNull
-import io.kotest.matchers.should
+import io.kotest.matchers.ranges.shouldBeIn
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldBeBlank
-import io.kotest.matchers.types.beOfType
 import io.kotest.matchers.types.shouldBeTypeOf
+import kotlinx.serialization.SerialName
 
 internal class SkillsClientTest : BaseWiremockTest() {
 
@@ -27,8 +32,9 @@ internal class SkillsClientTest : BaseWiremockTest() {
         context("Get skill of type") {
             withData(
                 mapOf(
-                    "armor" to ItemTestInput(10607, "10607-necro-util.json", ::necroUtilAssertion),
-                    "back" to ItemTestInput(10646, "10646-necro-elite.json", ::necroEliteAssertion),
+                    "necro-util" to SkillTestInput(10607, "10607-necro-util.json", ::necroUtilAssertion),
+                    "necro-elite" to SkillTestInput(10646, "10646-necro-elite.json", ::necroEliteAssertion),
+                    "revenant-heal" to SkillTestInput(62719, "62719-revenant-heal.json", ::revenantHealAssertion)
                 )
             ) { (id, responseFile, assertion) ->
                 // given
@@ -45,22 +51,105 @@ internal class SkillsClientTest : BaseWiremockTest() {
         }
     }
 
-    data class ItemTestInput(
+    data class SkillTestInput(
         val skillId: Int,
         val responseFile: String,
         val assertion: (skill: Skill) -> Unit,
     )
 
-    private fun necroUtilAssertion(skill: Skill) =
-        assertSoftly(skill) {
-            name shouldBe "Well of Darkness"
-            slot shouldBe SkillSlot.UTILITY
+    private fun necroUtilAssertion(skill: Skill) = assertSoftly(skill) {
+        name shouldBe "Well of Darkness"
+        slot shouldBe SkillSlot.UTILITY
+        description shouldBe "Well. Target area pulses, blinding foes with each pulse."
+        weaponType shouldBe "None"
+        chatLink shouldBe "[&Bm8pAAA=]"
+        type shouldBe SkillType.UTILITY
+        skillType.shouldBeNull()
+        professions shouldContainExactly listOf("Necromancer")
+        slot shouldBe SkillSlot.UTILITY
+        facts shouldHaveSize 10
+        assertSoftly(facts[0]) {
+            text shouldBe "Range"
+            shouldBeTypeOf<Range>()
+            value shouldBe 900
         }
-    private fun necroEliteAssertion(skill: Skill) =
-        assertSoftly(skill) {
-            name shouldBe "Summon Flesh Golem"
-            slot shouldBe SkillSlot.ELITE
+        flags shouldContainExactly listOf("GroundTargeted")
+        traitedFacts.shouldBeEmpty()
+        categories shouldContainExactly listOf("Well")
+        attunement.shouldBeNull()
+        cost.shouldBeNull()
+        dualWield.shouldBeNull()
+        flipSkill.shouldBeNull()
+        initiative.shouldBeNull()
+        nextChain.shouldBeNull()
+        previousChain.shouldBeNull()
+    }
+
+    private fun necroEliteAssertion(skill: Skill) = assertSoftly(skill) {
+        name shouldBe "Summon Flesh Golem"
+        slot shouldBe SkillSlot.ELITE
+        description shouldBe "Minion. Summon a flesh golem to attack foes with crippling claws."
+        weaponType shouldBe "None"
+        chatLink shouldBe "[&BpYpAAA=]"
+        type shouldBe SkillType.ELITE
+        skillType.shouldBeNull()
+        professions shouldContainExactly listOf("Necromancer")
+        slot shouldBe SkillSlot.ELITE
+        facts shouldHaveSize 4
+        assertSoftly(facts[0]) {
+            text shouldBe "Recharge"
+            shouldBeTypeOf<Recharge>()
+            value shouldBe 48
         }
+        flags.shouldBeEmpty()
+        traitedFacts shouldHaveSize 2
+        assertSoftly(traitedFacts[0]) {
+            requiresTrait shouldBe 858
+            overrides shouldBe 1
+            // TODO TraitedFacts type not done yet
+            // shouldBeTypeOf<Damage>()
+            // text shouldBe "Damage"
+            // hitCount shouldBe 1
+            // dmgMultiplier shouldBe (0.375 plusOrMinus 0.01)
+        }
+        categories shouldContainExactly listOf("Minion")
+        attunement.shouldBeNull()
+        cost.shouldBeNull()
+        dualWield.shouldBeNull()
+        flipSkill shouldBe 10647
+        initiative.shouldBeNull()
+        nextChain.shouldBeNull()
+        previousChain.shouldBeNull()
+    }
+
+    private fun revenantHealAssertion(skill: Skill) = assertSoftly(skill) {
+        name shouldBe "Selfish Spirit"
+        slot shouldBe SkillSlot.HEAL
+        description shouldBe "Legendary Alliance. Channel your rage into the nearby area, healing and empowering yourself for each enemy struck."
+        weaponType shouldBe "None"
+        chatLink shouldBe "[&Bv/0AAA=]"
+        type shouldBe SkillType.HEAL
+        skillType.shouldBeNull()
+        professions shouldContainExactly listOf("Revenant")
+        slot shouldBe SkillSlot.HEAL
+        facts shouldHaveSize 9
+        assertSoftly(facts[3]) {
+            text shouldBe "Healing per Hit"
+            shouldBeTypeOf<AttributeAdjust>()
+            value shouldBe 714
+            target shouldBe "Healing"
+        }
+        flags.shouldBeEmpty()
+        traitedFacts.shouldBeEmpty()
+        categories.shouldBeEmpty()
+        attunement.shouldBeNull()
+        cost shouldBe 10
+        dualWield.shouldBeNull()
+        flipSkill shouldBe 62680
+        initiative.shouldBeNull()
+        nextChain.shouldBeNull()
+        previousChain.shouldBeNull()
+    }
 
 
 }

--- a/src/test/kotlin/io/github/kryszak/gwatlin/api/skills/SkillsClientTest.kt
+++ b/src/test/kotlin/io/github/kryszak/gwatlin/api/skills/SkillsClientTest.kt
@@ -1,0 +1,66 @@
+package io.github.kryszak.gwatlin.api.skills
+
+import io.github.kryszak.gwatlin.api.ApiLanguage.EN
+import io.github.kryszak.gwatlin.api.gamemechanics.GWSkillsClient
+import io.github.kryszak.gwatlin.api.gamemechanics.model.skill.Skill
+import io.github.kryszak.gwatlin.api.gamemechanics.model.skill.SkillSlot
+import io.github.kryszak.gwatlin.api.items.model.item.*
+import io.github.kryszak.gwatlin.config.BaseWiremockTest
+import io.kotest.assertions.assertSoftly
+import io.kotest.datatest.withData
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldBeBlank
+import io.kotest.matchers.types.beOfType
+import io.kotest.matchers.types.shouldBeTypeOf
+
+internal class SkillsClientTest : BaseWiremockTest() {
+
+    private val skillsClient = GWSkillsClient()
+
+    init {
+        context("Get skill of type") {
+            withData(
+                mapOf(
+                    "armor" to ItemTestInput(10607, "10607-necro-util.json", ::necroUtilAssertion),
+                    "back" to ItemTestInput(10646, "10646-necro-elite.json", ::necroEliteAssertion),
+                )
+            ) { (id, responseFile, assertion) ->
+                // given
+                val lang = EN
+                stubResponse("/skills?ids=$id", "/responses/skills/$responseFile", language = lang)
+
+                // when
+                val items = skillsClient.getSkills(listOf(id), lang)
+
+                // then
+                items shouldHaveSize 1
+                assertion(items[0])
+            }
+        }
+    }
+
+    data class ItemTestInput(
+        val skillId: Int,
+        val responseFile: String,
+        val assertion: (skill: Skill) -> Unit,
+    )
+
+    private fun necroUtilAssertion(skill: Skill) =
+        assertSoftly(skill) {
+            name shouldBe "Well of Darkness"
+            slot shouldBe SkillSlot.UTILITY
+        }
+    private fun necroEliteAssertion(skill: Skill) =
+        assertSoftly(skill) {
+            name shouldBe "Summon Flesh Golem"
+            slot shouldBe SkillSlot.ELITE
+        }
+
+
+}

--- a/src/test/resources/responses/skills/10607-necro-util.json
+++ b/src/test/resources/responses/skills/10607-necro-util.json
@@ -1,0 +1,90 @@
+[
+  {
+    "name": "Well of Darkness",
+    "facts": [
+      {
+        "text": "Range",
+        "type": "Range",
+        "icon": "https://render.guildwars2.com/file/0AAB34BEB1C9F4A25EC612DDBEACF3E20B2810FA/156666.png",
+        "value": 900
+      },
+      {
+        "text": "Recharge",
+        "type": "Recharge",
+        "icon": "https://render.guildwars2.com/file/D767B963D120F077C3B163A05DC05A7317D7DB70/156651.png",
+        "value": 25
+      },
+      {
+        "text": "Damage",
+        "type": "Damage",
+        "icon": "https://render.guildwars2.com/file/61AA4919C4A7990903241B680A69530121E994C7/156657.png",
+        "hit_count": 6,
+        "dmg_multiplier": 0.8
+      },
+      {
+        "text": "Apply Buff/Condition",
+        "type": "Buff",
+        "icon": "https://render.guildwars2.com/file/09770136BB76FD0DBE1CC4267DEED54774CB20F6/102837.png",
+        "duration": 3,
+        "status": "Blinded",
+        "description": "Next outgoing attack misses; stacks duration.",
+        "apply_count": 1
+      },
+      {
+        "text": "Number of Targets",
+        "type": "Number",
+        "icon": "https://render.guildwars2.com/file/BBE8191A494B0352259C10EADFDACCE177E6DA5B/1770208.png",
+        "value": 5
+      },
+      {
+        "text": "Pulse",
+        "type": "Time",
+        "icon": "https://render.guildwars2.com/file/9352ED3244417304995F26CB01AE76BB7E547052/156661.png",
+        "duration": 1
+      },
+      {
+        "text": "Duration",
+        "type": "Time",
+        "icon": "https://render.guildwars2.com/file/7B2193ACCF77E56C13E608191B082D68AA0FAA71/156659.png",
+        "duration": 5
+      },
+      {
+        "text": "Radius",
+        "type": "Distance",
+        "icon": "https://render.guildwars2.com/file/B0CD8077991E4FB1622D2930337ED7F9B54211D5/156665.png",
+        "distance": 240
+      },
+      {
+        "text": "Apply Buff/Condition",
+        "type": "Buff",
+        "icon": "https://render.guildwars2.com/file/28C4EC547A3516AF0242E826772DA43A5EAC3DF3/102839.png",
+        "duration": 2,
+        "status": "Chilled",
+        "description": "Movement speed decreased by 66%; skill cooldown increased by 66%; stacks duration.",
+        "apply_count": 1
+      },
+      {
+        "text": "Combo Field",
+        "type": "ComboField",
+        "icon": "https://render.guildwars2.com/file/59E0DB6A699810641C959926ADFEF73E08CC255B/156655.png",
+        "field_type": "Dark"
+      }
+    ],
+    "description": "Well. Target area pulses, blinding foes with each pulse.",
+    "icon": "https://render.guildwars2.com/file/73CD1C36D50DD05FA009A5119166AF9BF665B5F1/103566.png",
+    "type": "Utility",
+    "weapon_type": "None",
+    "professions": [
+      "Necromancer"
+    ],
+    "slot": "Utility",
+    "flags": [
+      "GroundTargeted"
+    ],
+    "id": 10607,
+    "chat_link": "[&Bm8pAAA=]",
+    "categories": [
+      "Well"
+    ]
+  }
+]

--- a/src/test/resources/responses/skills/10646-necro-elite.json
+++ b/src/test/resources/responses/skills/10646-necro-elite.json
@@ -1,0 +1,72 @@
+[
+  {
+    "name": "Summon Flesh Golem",
+    "facts": [
+      {
+        "text": "Recharge",
+        "type": "Recharge",
+        "icon": "https://render.guildwars2.com/file/D767B963D120F077C3B163A05DC05A7317D7DB70/156651.png",
+        "value": 48
+      },
+      {
+        "text": "Damage",
+        "type": "Damage",
+        "icon": "https://render.guildwars2.com/file/61AA4919C4A7990903241B680A69530121E994C7/156657.png",
+        "hit_count": 1,
+        "dmg_multiplier": 0.3
+      },
+      {
+        "text": "Final Strike Damage",
+        "type": "Damage",
+        "icon": "https://render.guildwars2.com/file/61AA4919C4A7990903241B680A69530121E994C7/156657.png",
+        "hit_count": 1,
+        "dmg_multiplier": 0.5
+      },
+      {
+        "text": "Apply Buff/Condition",
+        "type": "Buff",
+        "icon": "https://render.guildwars2.com/file/070325E519C178D502A8160523766070D30C0C19/102838.png",
+        "duration": 1,
+        "status": "Crippled",
+        "description": "Movement speed decreased by 50%; stacks duration.",
+        "apply_count": 1
+      }
+    ],
+    "description": "Minion. Summon a flesh golem to attack foes with crippling claws.",
+    "icon": "https://render.guildwars2.com/file/0C9376D8AC320CB10F43D6F9D37B5458316AC9DF/103840.png",
+    "type": "Elite",
+    "weapon_type": "None",
+    "professions": [
+      "Necromancer"
+    ],
+    "slot": "Elite",
+    "flip_skill": 10647,
+    "flags": [],
+    "id": 10646,
+    "chat_link": "[&BpYpAAA=]",
+    "categories": [
+      "Minion"
+    ],
+    "traited_facts": [
+      {
+        "text": "Damage",
+        "type": "Damage",
+        "icon": "https://render.guildwars2.com/file/61AA4919C4A7990903241B680A69530121E994C7/156657.png",
+        "requires_trait": 858,
+        "hit_count": 1,
+        "dmg_multiplier": 0.375,
+        "overrides": 1
+      },
+      {
+        "text": "Final Strike Damage",
+        "type": "Damage",
+        "icon": "https://render.guildwars2.com/file/61AA4919C4A7990903241B680A69530121E994C7/156657.png",
+        "requires_trait": 858,
+        "hit_count": 1,
+        "dmg_multiplier": 0.625,
+        "overrides": 2
+      }
+    ]
+  }
+]
+

--- a/src/test/resources/responses/skills/62719-revenant-heal.json
+++ b/src/test/resources/responses/skills/62719-revenant-heal.json
@@ -1,0 +1,83 @@
+[
+  {
+    "name": "Selfish Spirit",
+    "facts": [
+      {
+        "text": "Range",
+        "type": "Range",
+        "icon": "https://render.guildwars2.com/file/0AAB34BEB1C9F4A25EC612DDBEACF3E20B2810FA/156666.png",
+        "value": 240
+      },
+      {
+        "text": "Recharge",
+        "type": "Recharge",
+        "icon": "https://render.guildwars2.com/file/D767B963D120F077C3B163A05DC05A7317D7DB70/156651.png",
+        "value": 10
+      },
+      {
+        "text": "Damage",
+        "type": "Damage",
+        "icon": "https://render.guildwars2.com/file/61AA4919C4A7990903241B680A69530121E994C7/156657.png",
+        "hit_count": 1,
+        "dmg_multiplier": 0.222
+      },
+      {
+        "text": "Healing per Hit",
+        "type": "AttributeAdjust",
+        "icon": "https://render.guildwars2.com/file/D4347C52157B040943051D7E09DEAD7AF63D4378/156662.png",
+        "value": 714,
+        "target": "Healing"
+      },
+      {
+        "text": "Apply Buff/Condition",
+        "type": "Buff",
+        "icon": "https://render.guildwars2.com/file/2FA9DF9D6BC17839BBEA14723F1C53D645DDB5E1/102852.png",
+        "duration": 5,
+        "status": "Might",
+        "description": "Increased outgoing damage; stacks intensity.",
+        "apply_count": 1
+      },
+      {
+        "text": "Apply Buff/Condition",
+        "type": "Buff",
+        "icon": "https://render.guildwars2.com/file/3A394C1A0A3257EB27A44842DDEEF0DF000E1241/102850.png",
+        "duration": 5,
+        "status": "Vulnerability",
+        "description": "Damage and condition damage taken are increased; stacks intensity.",
+        "apply_count": 1
+      },
+      {
+        "text": "Number of Targets",
+        "type": "Number",
+        "icon": "https://render.guildwars2.com/file/BBE8191A494B0352259C10EADFDACCE177E6DA5B/1770208.png",
+        "value": 5
+      },
+      {
+        "text": "Number of Casts",
+        "type": "Number",
+        "icon": "https://render.guildwars2.com/file/9352ED3244417304995F26CB01AE76BB7E547052/156661.png",
+        "value": 4
+      },
+      {
+        "text": "Radius",
+        "type": "Distance",
+        "icon": "https://render.guildwars2.com/file/B0CD8077991E4FB1622D2930337ED7F9B54211D5/156665.png",
+        "distance": 240
+      }
+    ],
+    "description": "Legendary Alliance. Channel your rage into the nearby area, healing and empowering yourself for each enemy struck.",
+    "icon": "https://render.guildwars2.com/file/5D42213C0E779954D393D190FF62D6F2EADBA03D/2491620.png",
+    "type": "Heal",
+    "weapon_type": "None",
+    "professions": [
+      "Revenant"
+    ],
+    "slot": "Heal",
+    "cost": 10,
+    "flip_skill": 62680,
+    "flags": [],
+    "specialization": 69,
+    "id": 62719,
+    "chat_link": "[&Bv/0AAA=]"
+  }
+]


### PR DESCRIPTION
Added a missing value "Elite" in enum `SkillSlot`. Example here <https://api.guildwars2.com/v2/skills?ids=10646> and but this seems to be [undocumented](https://wiki.guildwars2.com/wiki/API:2/skills) as well.