### PR TITLE
achievement types update properties

### DIFF
--- a/src/main/kotlin/io/github/kryszak/gwatlin/api/achievement/model/Achievement.kt
+++ b/src/main/kotlin/io/github/kryszak/gwatlin/api/achievement/model/Achievement.kt
@@ -16,6 +16,6 @@ data class Achievement(
         val type: String,
         val flags: List<String>,
         val tiers: List<AchievementTier>,
-        val rewards: List<AchievementReward>,
+        val rewards: List<AchievementReward> = listOf(),
         val bits: List<AchievementBit> = listOf()
 )

--- a/src/main/kotlin/io/github/kryszak/gwatlin/api/achievement/model/Achievement.kt
+++ b/src/main/kotlin/io/github/kryszak/gwatlin/api/achievement/model/Achievement.kt
@@ -14,8 +14,8 @@ data class Achievement(
         val requirement: String,
         @SerialName("locked_text") val lockedText: String,
         val type: String,
-        val flags: List<String>,
-        val tiers: List<AchievementTier>,
+        val flags: List<String> = listOf(),
+        val tiers: List<AchievementTier> = listOf(),
         val rewards: List<AchievementReward> = listOf(),
         val bits: List<AchievementBit> = listOf()
 )

--- a/src/main/kotlin/io/github/kryszak/gwatlin/api/achievement/model/AchievementBit.kt
+++ b/src/main/kotlin/io/github/kryszak/gwatlin/api/achievement/model/AchievementBit.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class AchievementBit(
-    val type: AchievementBitType,
+    val type: AchievementBitType? = null,
     val id: Int? = null,
     val text: String? = null
 )

--- a/src/test/kotlin/io/github/kryszak/gwatlin/api/achievement/AchievementsClientTest.kt
+++ b/src/test/kotlin/io/github/kryszak/gwatlin/api/achievement/AchievementsClientTest.kt
@@ -6,7 +6,6 @@ import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.collections.shouldMatchEach
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 

--- a/src/test/kotlin/io/github/kryszak/gwatlin/api/achievement/AchievementsClientTest.kt
+++ b/src/test/kotlin/io/github/kryszak/gwatlin/api/achievement/AchievementsClientTest.kt
@@ -66,7 +66,7 @@ internal class AchievementsClientTest : BaseWiremockTest() {
             // then
             achievementList shouldHaveSize 1
             assertSoftly(achievementList[0]) {
-                this.id shouldBe 3137
+                this.id shouldBe 3147
                 name shouldBe "Walking on Fire"
                 rewards shouldHaveSize 0
             }

--- a/src/test/kotlin/io/github/kryszak/gwatlin/api/achievement/AchievementsClientTest.kt
+++ b/src/test/kotlin/io/github/kryszak/gwatlin/api/achievement/AchievementsClientTest.kt
@@ -6,6 +6,8 @@ import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldMatchEach
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 
 internal class AchievementsClientTest : BaseWiremockTest() {
@@ -49,6 +51,46 @@ internal class AchievementsClientTest : BaseWiremockTest() {
                 assertSoftly(rewards[0]) {
                     type shouldBe "Item"
                     count shouldBe 1
+                }
+            }
+        }
+
+        should("Get 3147: Walking on Fire") {
+            // given
+            val id = 3147
+            stubResponse("/achievements?ids=3147", "/responses/achievements/3147-walking-on-fire.json")
+
+            // when
+            val achievementList = achievementsClient.getAchievementsByIds(listOf(id))
+
+            // then
+            achievementList shouldHaveSize 1
+            assertSoftly(achievementList[0]) {
+                this.id shouldBe 3137
+                name shouldBe "Walking on Fire"
+                rewards shouldHaveSize 0
+            }
+        }
+
+        should("Get 5585: Dragon Ice Infuser") {
+            // given
+            val id = 5585
+            stubResponse("/achievements?ids=5585", "/responses/achievements/5585-dragon-ice-infuser.json")
+
+            // when
+            val achievementList = achievementsClient.getAchievementsByIds(listOf(id))
+
+            // then
+            achievementList shouldHaveSize 1
+            assertSoftly(achievementList[0]) {
+                this.id shouldBe 5585
+                name shouldBe "Dragon Ice Infuser"
+                bits shouldHaveSize 16
+                bits.distinct() shouldHaveSize 1
+                assertSoftly(bits[0]) {
+                    type.shouldBeNull()
+                    this.id.shouldBeNull()
+                    text.shouldBeNull()
                 }
             }
         }

--- a/src/test/resources/responses/achievements/3147-walking-on-fire.json
+++ b/src/test/resources/responses/achievements/3147-walking-on-fire.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": 3147,
+    "name": "Walking on Fire",
+    "description": "Don't look down!",
+    "requirement": "Navigate the lava tunnel in Ember Bay.",
+    "locked_text": "",
+    "type": "Default",
+    "flags": [
+      "Permanent"
+    ],
+    "tiers": [
+      {
+        "count": 1,
+        "points": 1
+      }
+    ]
+  }
+]

--- a/src/test/resources/responses/achievements/5585-dragon-ice-infuser.json
+++ b/src/test/resources/responses/achievements/5585-dragon-ice-infuser.json
@@ -1,0 +1,67 @@
+[
+  {
+    "id": 5585,
+    "name": "Dragon Ice Infuser",
+    "description": "",
+    "requirement": "Unlock all recipes to craft the Azure Dragon Slayer weapons.",
+    "locked_text": "",
+    "type": "ItemSet",
+    "flags": [
+      "Pvp",
+      "RepairOnLogin",
+      "Permanent"
+    ],
+    "bits": [
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {}
+    ],
+    "tiers": [
+      {
+        "count": 2,
+        "points": 1
+      },
+      {
+        "count": 4,
+        "points": 1
+      },
+      {
+        "count": 6,
+        "points": 2
+      },
+      {
+        "count": 8,
+        "points": 2
+      },
+      {
+        "count": 10,
+        "points": 2
+      },
+      {
+        "count": 12,
+        "points": 3
+      },
+      {
+        "count": 14,
+        "points": 4
+      },
+      {
+        "count": 16,
+        "points": 5
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Reference <https://wiki.guildwars2.com/wiki/API:2/achievements>

* `AchievementBit`: API spec says type is required, but at least Dragon Ice Infuser returns array of empty bit objects
* `Achievement`, the _Walking on Fire_ doesn't have rewards attached to it, so it now has a default value of empty list.